### PR TITLE
fix: Remove hard-coded jwt signing key

### DIFF
--- a/src/main/resources/application-non-prd.yml
+++ b/src/main/resources/application-non-prd.yml
@@ -59,7 +59,7 @@ springdoc:
 
 jwt:
   access-token:
-    signing-key: ajsfjkHJKHKHFKDJsafadsfnkjdhkfhadsHJKHkjsadf
+    signing-key: ${SIGN_IN_KEY}
     expiration-time: 3600000 # Expiration time in milliseconds (1 hour)
   refresh-token:
     long-duration:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/skappHQ/skapp-be/blob/main/CONTRIBUTING.md) file - YES

## PR checklist

### Issue ID: [#155](https://github.com/skappHQ/skapp-be/issues/155)

### Summary

The value set in the environment variable `SIGN_IN_KEY` is over-written by a hard-coded value.

Check out [the issue description](https://github.com/SkappHQ/skapp-be/issues/155#issue-2844902117) for more information.

### How to test

1. Check if the generated JWTs can be verified using the value set in `SIGN_IN_KEY` env variable. Can use [this tool](https://jwt.io/). I have tested this and it works as expected after the change.

### Project Checklist
Please add an `x` to mark the checkbox:

- [x] Changes build without any errors
- [ ] Have written adequate test cases
- [x] Done developer testing
- [x] No unnecessary comments left in the code

#### Other

- [ ] New endpoint(s) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is created to the correct base branch
- [x] Pull request is created with the correct branch name
- [x] Pull request is created with a meaningful title
- [x] Pull request is self reviewed
- [ ] Suitable pull request status labels are added (`ready-for-code-review` & `waiting-for-developer-testing`)

### Additional Information
